### PR TITLE
Cast window coordinates to integer

### DIFF
--- a/gym_go/envs/go_env.py
+++ b/gym_go/envs/go_env.py
@@ -192,8 +192,8 @@ class GoEnv(gym.Env):
             from pyglet.window import key
 
             screen = pyglet.window.get_platform().get_default_display().get_default_screen()
-            window_width = min(screen.width, screen.height) * 2 / 3
-            window_height = window_width * 1.2
+            window_width = min(screen.width, screen.height) * 2 // 3
+            window_height = int(window_width * 1.2)
             window = pyglet.window.Window(window_width, window_height)
 
             self.window = window


### PR DESCRIPTION
While rendering pyglet Window object, window width and height should
be given as integers (instead of floating-point numbers).
Problem observed using XFCE4 on Xubuntu 18.04 LTS